### PR TITLE
Add support for starting the devise setup with setupOnly

### DIFF
--- a/src/particle.android.ts
+++ b/src/particle.android.ts
@@ -175,7 +175,7 @@ export class Particle implements TNSParticleAPI {
     return io.particle.android.sdk.cloud.ParticleCloudSDK.getCloud().getAccessToken();
   }
 
-  public startDeviceSetupWizard(): Promise<boolean> {
+  public startDeviceSetupWizard(o?: { setupOnly: boolean; }): Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
       // note that since we _have_ to return an intent, the activity is relaunched, so there's some state juggling required in the app
       const intent = AndroidApp.foregroundActivity.getIntent();
@@ -190,6 +190,7 @@ export class Particle implements TNSParticleAPI {
       io.particle.android.sdk.devicesetup.ParticleDeviceSetupLibrary.startDeviceSetup(utils.ad.getApplicationContext(), builder);
     });
   }
+
 
   public getDeviceSetupCustomizer(): any {
     // stub for getDeviceSetupCustomizer

--- a/src/particle.common.ts
+++ b/src/particle.common.ts
@@ -87,7 +87,7 @@ export interface TNSParticleAPI {
 
   listDevices(): Promise<Array<TNSParticleDevice>>;
 
-  startDeviceSetupWizard(): Promise<boolean>;
+  startDeviceSetupWizard(o?: { setupOnly: boolean; }): Promise<boolean>;
 
   getDeviceSetupCustomizer(): any;
 

--- a/src/particle.ios.ts
+++ b/src/particle.ios.ts
@@ -234,9 +234,12 @@ export class Particle implements TNSParticleAPI {
     this.eventIds.delete(prefix);
   }
 
-  public startDeviceSetupWizard(): Promise<boolean> {
+  public startDeviceSetupWizard(o?: { setupOnly: boolean; }): Promise<boolean> {
+    if (!o) {
+      o = { setupOnly: false };
+    }
     return new Promise<boolean>((resolve, reject) => {
-      const setupController = ParticleSetupMainController.new();
+      const setupController = ParticleSetupMainController.new().initWithSetupOnly(o.setupOnly);
       this.wizardDelegate = ParticleSetupControllerDelegateImpl.createWithOwnerAndCallback(new WeakRef(this), (result: boolean) => resolve(result));
       setupController.delegate = <any>this.wizardDelegate;
       UIApplication.sharedApplication.keyWindow.rootViewController.presentViewControllerAnimatedCompletion(setupController, true, null);

--- a/src/particle.ios.ts
+++ b/src/particle.ios.ts
@@ -239,7 +239,7 @@ export class Particle implements TNSParticleAPI {
       o = { setupOnly: false };
     }
     return new Promise<boolean>((resolve, reject) => {
-      const setupController = ParticleSetupMainController.new().initWithSetupOnly(o.setupOnly);
+      const setupController = new ParticleSetupMainController({setupOnly: true});
       this.wizardDelegate = ParticleSetupControllerDelegateImpl.createWithOwnerAndCallback(new WeakRef(this), (result: boolean) => resolve(result));
       setupController.delegate = <any>this.wizardDelegate;
       UIApplication.sharedApplication.keyWindow.rootViewController.presentViewControllerAnimatedCompletion(setupController, true, null);


### PR DESCRIPTION
This PR is a stab at adding `setupOnly` mode for iOS.

I modified the `startDeviceSetupWizard` since it already manages the promise, the wizard delegate, and presenting the controller.

I can see separating this out into its own method to reduce the chance of future conflict with the official SDK, but I wanted to show some code first. 

WDYT @EddyVerbruggen?